### PR TITLE
accounted for underscores

### DIFF
--- a/qa_test_doc.py
+++ b/qa_test_doc.py
@@ -517,6 +517,7 @@ QA Test Suite Documentation
     def write_introfiles(self, file_dict):        
         for folder_path, test in file_dict.items():
             folder = folder_path.strip().split('/')[-1]
+            title = folder.replace("_"," ")
             filename = '{}/intro_{}.rst'.format(self._doc_dir,folder)
             intro = """
 .. {}-qa-tests:
@@ -524,7 +525,7 @@ QA Test Suite Documentation
 {} QA Tests
 {}
 
-            """.format(folder,folder,'='*(len(folder)+9))
+            """.format(folder,title,'='*(len(title)+9))
             
             intro_links = [None]*len(test)
             if len(test) == 1:


### PR DESCRIPTION
This fixes the problem of sphinx not recognizing spaces in file name paths. Therefore a folder must be called 'Kolditz_Tests' to be displayed as 'Kolditz Tests' on the documentation