### PR TITLE
Glenn/command line files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 PYTHON = python3
 QA_TEST_SUITE = qa_test_suite.py
 DOC_DIR = ${PWD}/docs
+CONFIG_FILE = config_files.txt
+SIMULATORS_FILE = simulators.sim
 
 all : clean_tests run_tests
 
@@ -37,7 +39,7 @@ clean_tests :
 	-find . -type f -name 'successful_regression_tests.log' -print0 | xargs -0 -r rm
 
 run_tests :
-	$(PYTHON) $(QA_TEST_SUITE) --doc_dir $(DOC_DIR)
+	$(PYTHON) $(QA_TEST_SUITE) --doc_dir $(DOC_DIR) --config_file $(CONFIG_FILE) --simulators_file $(SIMULATORS_FILE)
 
 run_incremental_tests :
-	$(PYTHON) $(QA_TEST_SUITE) --doc_dir $(DOC_DIR) --incremental_testing
+	$(PYTHON) $(QA_TEST_SUITE) --doc_dir $(DOC_DIR) --config_file $(CONFIG_FILE) --simulators_file $(SIMULATORS_FILE) --incremental_testing

--- a/qa_test.py
+++ b/qa_test.py
@@ -201,11 +201,10 @@ class QATest(object):
         list_of_swap_dict=self._process_swap_options()
         self._check_simulators(available_simulators)
 
-
         cwd = os.getcwd()
-        print(cwd)
-        print(self.root_dir)
-        print(cwd.replace(self.root_dir,''))
+#        print(cwd)
+#        print(self.root_dir)
+#        print(cwd.replace(self.root_dir,''))
 
         self.doc = QATestDoc(cwd,cwd.replace(self.root_dir,''))
         self.doc.set_title(self.title)

--- a/qa_test_suite.py
+++ b/qa_test_suite.py
@@ -85,7 +85,6 @@ def main(options):
     check_options(options)
     print(options)
     
-
     print("Running QA tests :") 
     
     config_filename = options.config_file
@@ -99,7 +98,6 @@ def main(options):
     config_files = []
     path = os.path.dirname(os.path.realpath(__file__))
     config_files.append('{}/regression_tests/test.cfg'.format(path))
-    print(config_files)
     for line in open(config_filename,'r'):
         line=line.strip()
           # rstrip to remove EOL. otherwise, errors when opening file
@@ -120,13 +118,10 @@ def main(options):
     report = {}
     for config_file in config_files:
         os.chdir(root_dir)
-        print(config_file)
         
         test_manager = QATestManager(simulators_dict)
         test_manager.process_config_file(root_dir,config_file,testlog)
         test_manager.run_tests(testlog)
-
-
 
     doc = QATestDocIndex(testlog,options.doc_dir)
     doc.write_index()

--- a/qa_test_suite.py
+++ b/qa_test_suite.py
@@ -82,8 +82,6 @@ def scanfolder(parent_dir,extension):
 def main(options):
     txtwrap = textwrap.TextWrapper(width=78, subsequent_indent=4*" ")
     
-    root_dir = os.getcwd()
-       
     check_options(options)
     print(options)
     
@@ -93,11 +91,15 @@ def main(options):
     config_filename = options.config_file
     if not os.path.exists(config_filename):
         config_filename = 'default_config_files.txt'
-    config_root_dir = os.path.dirname(config_filename)
+    root_dir = os.path.dirname(config_filename)
+    if root_dir == '':
+        root_dir = os.getcwd()
     
     # regression tests must come first in list of config files
     config_files = []
-    config_files.append('{}/regression_tests/test.cfg'.format(root_dir)) 
+    path = os.path.dirname(os.path.realpath(__file__))
+    config_files.append('{}/regression_tests/test.cfg'.format(path))
+    print(config_files)
     for line in open(config_filename,'r'):
         line=line.strip()
           # rstrip to remove EOL. otherwise, errors when opening file
@@ -105,7 +107,7 @@ def main(options):
             if line.startswith('/'):
                 full_path = line.rstrip()
             else:
-                full_path = config_root_dir+'/'+line.rstrip()
+                full_path = root_dir+'/'+line.rstrip()
             config_files.append(full_path) 
 
     simulators_dict = locate_simulators(options.simulators_file) 
@@ -117,12 +119,11 @@ def main(options):
     start = time.time()
     report = {}
     for config_file in config_files:
-        if not config_root_dir == '':
-            os.chdir(config_root_dir)
+        os.chdir(root_dir)
         print(config_file)
         
         test_manager = QATestManager(simulators_dict)
-        test_manager.process_config_file(config_root_dir,config_file,testlog)
+        test_manager.process_config_file(root_dir,config_file,testlog)
         test_manager.run_tests(testlog)
 
 

--- a/qa_test_suite.py
+++ b/qa_test_suite.py
@@ -117,7 +117,8 @@ def main(options):
     start = time.time()
     report = {}
     for config_file in config_files:
-        os.chdir(config_root_dir)
+        if not config_root_dir == '':
+            os.chdir(config_root_dir)
         print(config_file)
         
         test_manager = QATestManager(simulators_dict)

--- a/simulator_modules/simulator_factory.py
+++ b/simulator_modules/simulator_factory.py
@@ -13,20 +13,18 @@ from simulator_modules.tough2 import QASimulatorTOUGH2
 from simulator_modules.tough3 import QASimulatorTOUGH3
 from simulator_modules.tdycore import QASimulatorTDycore
 
-
-
-def locate_simulators():
+def locate_simulators(simulators_filename):
     debug_push('simulator_factory.locate_simulators')
-    if os.path.exists('simulators.sim'):
-      sim_file = 'simulators.sim'
-    else:
-      sim_file='default_simulators.sim'
+    sim_file = simulators_filename
+    if not os.path.exists(sim_file):
+        sim_file='default_simulators.sim'
     config = configparser.ConfigParser()
     config.read(sim_file)
     simulators = config.items('simulators')
     simulator_dict = {}
     to_be_removed = []
     for simulator, path in simulators:
+        path = os.path.expandvars(path)
         if debug_verbose():
             print('Searching for "{}" mapped to "{}".'.format(path,simulator))
         if not os.path.isfile(path):


### PR DESCRIPTION
Allows the user to specify configuration and simulator files that use non-standard names and can be located outside of the toolbox.