### PR TITLE
fix 1D finder

### DIFF
--- a/qa_common.py
+++ b/qa_common.py
@@ -184,10 +184,10 @@ def find_axis_1D(x,y,z):
         if check_array_equal(x)==False:
             x_axis = x
     elif len(y)>1:
-        if check_array_equal(x)==False:
+        if check_array_equal(y)==False:
             x_axis = y
     elif len(z)>1:
-        if check_array_equal(x)==False:
+        if check_array_equal(z)==False:
             x_axis = z
     try:   
         if x_axis == None:


### PR DESCRIPTION
When finding 1D direction, x was being used for y and z. I changed to respectively y and z.